### PR TITLE
Migration failure handling

### DIFF
--- a/WikipediaUnitTests/OldDataSchemaMigratorTests.m
+++ b/WikipediaUnitTests/OldDataSchemaMigratorTests.m
@@ -76,18 +76,41 @@
     [self verifyMigrationOfArticle:oldArticle];
 }
 
-- (void)testMigrationOfBadArticle{
-    
+- (void)testArticleWithMissingRequiredFieldsIsGracefullySkipped {
     Article* oldArticle = [self createOldArticleWithSections:10 imagesPerSection:5];
-    
+    // lastModified is a required field
     oldArticle.lastmodified = nil;
-    oldArticle.displayTitle = nil;
-    
-    XCTAssertNoThrow([self.migrator migrateArticle:oldArticle]);
+    [self verifySkippedMigrationOfArticle:oldArticle];
 }
 
+- (void)testArticleWithInvalidSectionIsGracefullySkipped {
+    Article* oldArticle = [self createOldArticleWithSections:10 imagesPerSection:5];
+    Section* section = oldArticle.sectionsBySectionId.lastObject;
+    // sectionId is a required field
+    section.sectionId = nil;
+    [self verifySkippedMigrationOfArticle:oldArticle];
+}
+
+- (void)testArticleWithInvalidSectionImageIsGracefullySkipped {
+    Article* oldArticle = [self createOldArticleWithSections:10 imagesPerSection:5];
+    Section* section = oldArticle.sectionsBySectionId.lastObject;
+    SectionImage* image = section.sectionImagesByIndex.lastObject;
+    // sourceUrl is a required field
+    image.image.sourceUrl = nil;
+
+    [self verifySkippedMigrationOfArticle:oldArticle];
+}
 
 #pragma mark - Test Utils
+
+- (void)verifySkippedMigrationOfArticle:(Article*)oldArticle {
+    XCTAssertNoThrow([self.migrator migrateArticle:oldArticle],
+                     @"Failed to catch an article migration exception.");
+    MWKTitle* migratedArticleTitle = [self.migrator migrateArticleTitle:oldArticle];
+    NSString* articleDataPath = [self.dataStore pathForTitle:migratedArticleTitle];
+    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:articleDataPath],
+                   @"Expected article to not be saved due to exception during migration.");
+}
 
 - (void)verifyMigrationOfArticle:(Article*)oldArticle {
     [self.migrator migrateArticle:oldArticle];

--- a/WikipediaUnitTests/OldDataSchemaMigratorTests.m
+++ b/WikipediaUnitTests/OldDataSchemaMigratorTests.m
@@ -97,7 +97,6 @@
     SectionImage* image = section.sectionImagesByIndex.lastObject;
     // sourceUrl is a required field
     image.image.sourceUrl = nil;
-
     [self verifySkippedMigrationOfArticle:oldArticle];
 }
 

--- a/wikipedia/Data/OldDataSchemaMigrator.m
+++ b/wikipedia/Data/OldDataSchemaMigrator.m
@@ -143,8 +143,9 @@
         // Record for later to avoid dupe imports
         [self.savedTitles addObject:key];
 
+    MWKArticle* migratedArticle;
         @try {
-            MWKArticle* migratedArticle = [self.delegate oldDataSchema:self migrateArticle:[self exportArticle:article]];
+            migratedArticle = [self.delegate oldDataSchema:self migrateArticle:[self exportArticle:article]];
 
             Image* thumbnail = article.thumbnailImage;
             if (thumbnail) {
@@ -167,11 +168,9 @@
             }
 
             [migratedArticle save];
-
         }
         @catch (NSException *exception) {
-            NSLog(@"Failed to save imported article: %@", exception);
-            NSParameterAssert(exception);
+            NSLog(@"Failed to migrate article due to exception: %@. Removing data.", exception);
         }
     }
 }

--- a/wikipedia/Data/OldDataSchemaMigrator.m
+++ b/wikipedia/Data/OldDataSchemaMigrator.m
@@ -171,6 +171,7 @@
         }
         @catch (NSException *exception) {
             NSLog(@"Failed to migrate article due to exception: %@. Removing data.", exception);
+            [migratedArticle remove];
         }
     }
 }


### PR DESCRIPTION
Adding more tests for negative migration edge cases:

- Invalid section data
- Invalid image data

and making sure we remove the article's data if an exception occurs during migration.

**Note:** we should look into whether deleting the entire article is necessary if a single image fails to migrate.